### PR TITLE
Fix splitUntil

### DIFF
--- a/Nodes.php
+++ b/Nodes.php
@@ -196,18 +196,21 @@ class TagNode extends Node {
 					$pastSplit = true;
 				}
 			}
+			
+			// Replace the existing child with $part1 (left) and $part2 (right).
+			// Insertions shift existing content right, so insert part2 before
+			// inserting part1.
 			$myindexinparent = $this->parent->getIndexOf($this);
-			if (!empty($part1->children)) {
-				$this->parent->addChildAbsolute($part1, $myindexinparent);
-			}
+			$this->parent->removeChild($myindexinparent);
 			if (!empty($part2->children)) {
 				$this->parent->addChildAbsolute($part2, $myindexinparent);
+			}
+			if (!empty($part1->children)) {
+				$this->parent->addChildAbsolute($part1, $myindexinparent);
 			}
 			if (!empty($part1->children) && !empty($part2->children)) {
 				$splitOccured = true;
 			}
-
-			$this->parent->removeChild($myindexinparent);
 
 			if ($includeLeft) {
 				$this->parent->splitUntil($parent, $part1, $includeLeft);


### PR DESCRIPTION
splitUntil() tries to replace "original" with "part1 part2", but before this commit, it took actions in the wrong order.  It added part1, then added part2, then removed original.  For example:
a b original c d
become
a b part1 original c d
then
a b part2 part1 original c d
then
a b part1 original c d
This commit changes the function to first remove original, then add part2, then add part1:
a b c d
a b part2 c d
a b part1 part2 c d

Here is an example problem at the application level:
<?php
require_once('htmldiff/html_diff.php');

$old="<span>Sentence</span><br/>
<p>These word</p>";

$new="Sentence <br/>
<p><strong>These words</strong></p>";

echo html_diff($old, $new)."\n";
?>
